### PR TITLE
Update distributions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,6 @@
 [flake8]
 ignore = 
-    E731
     W503
-    F401
 exclude = 
     pyproject.toml
     poetry.lock

--- a/src/torchnf/conditioners.py
+++ b/src/torchnf/conditioners.py
@@ -2,7 +2,7 @@
 The :code:`forward` method should return a set of parameters upon which the
 transformer should be conditioned.
 """
-from typing import Callable, Optional, Union
+from typing import Optional, Union
 import torch
 
 import torchnf.utils

--- a/src/torchnf/distributions.py
+++ b/src/torchnf/distributions.py
@@ -111,7 +111,9 @@ class IterablePrior(torch.utils.data.IterableDataset):
     def __next__(self):
         return self.sample()
 
-    def sample(self, sample_shape: Iterable[int] = torch.Size([])) -> torch.Tensor:
+    def sample(
+        self, sample_shape: Iterable[int] = torch.Size([])
+    ) -> torch.Tensor:
         # NOTE: define these explicitly rather than relying on getattr, since
         # otherwise does not register as instance of Prior
         return self.distribution.sample(sample_shape)

--- a/src/torchnf/flow.py
+++ b/src/torchnf/flow.py
@@ -1,4 +1,3 @@
-from typing import Callable, NamedTuple, Optional, Union
 import torch
 
 import torchnf.conditioners

--- a/src/torchnf/metrics.py
+++ b/src/torchnf/metrics.py
@@ -1,7 +1,5 @@
 """
 """
-import math
-import random
 from typing import Optional
 
 import torch

--- a/src/torchnf/models.py
+++ b/src/torchnf/models.py
@@ -423,7 +423,8 @@ class BoltzmannGenerator(Model):
             log_weights = log_prob_target - log_prob_prior + log_det_jacob
             return y, log_weights
         """
-        x, log_prob_prior = self.prior.forward(batch_size)
+        x = self.prior.sample([batch_size])
+        log_prob_prior = self.prior.log_prob(x)
         y, log_det_jacob = self.flow.forward(x)
         log_prob_target = self.target.log_prob(y)
         log_weights = log_prob_target - log_prob_prior + log_det_jacob
@@ -579,7 +580,9 @@ class BoltzmannGenerator(Model):
         """
         # Initialise with a random state drawn from the prior
         if self.mcmc_current_state is None:
-            self.mcmc_current_state = self.prior.forward(1)
+            x = self.prior.sample([1])
+            log_prob = self.prior.log_prob(x)
+            self.mcmc_current_state = (x, log_prob)
 
         out = []
 

--- a/src/torchnf/recipes/models.py
+++ b/src/torchnf/recipes/models.py
@@ -24,9 +24,9 @@ class MultivariateGaussianSampler(torchnf.models.BoltzmannGenerator):
             covariance_matrix=covariance_matrix,
             precision_matrix=precision_matrix,
         )
-        prior = torchnf.distributions.SimplePrior(
+        prior = torchnf.distributions.expand_dist(
             torch.distributions.Normal(0, 1),
-            expand_shape=target.event_shape,
+            target.event_shape,
         )
         super().__init__(
             prior=prior,

--- a/src/torchnf/transformers.py
+++ b/src/torchnf/transformers.py
@@ -37,7 +37,7 @@ for the forward and inverse transformations are related by
 
 import logging
 import math
-from typing import ClassVar, NamedTuple
+from typing import ClassVar
 
 import torch
 import torch.nn.functional as F

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -4,7 +4,7 @@ import random
 
 import torch.distributions
 
-from torchnf.distributions import Prior, SimplePrior
+from torchnf.distributions import SimplePrior
 
 _builtin_distributions = [
     torch.distributions.Normal(0, 1),

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,55 +1,57 @@
 import math
 import pytest
 import random
+from hypothesis import given, strategies as st
 
-import torch.distributions
+import torch
 
-from torchnf.distributions import SimplePrior
+from torchnf.distributions import Prior, Target, IterablePrior, expand_dist
 
-_builtin_distributions = [
+_distributions = [
     torch.distributions.Normal(0, 1),
     torch.distributions.Uniform(0, 2 * math.pi),
     torch.distributions.VonMises(0, 1),
     torch.distributions.MultivariateNormal(torch.zeros(2), torch.eye(2)),
 ]
-_data_shape = [6, 6]
-_batch_size = 10
+
+def test_types():
+    dist = torch.distributions.Normal(0, 1)
+    assert isinstance(dist, Prior)
+    assert isinstance(dist, Target)
+    assert not isinstance(dist, IterablePrior)
+
+    idist = IterablePrior(dist)
+    assert isinstance(idist, Prior)
+    assert isinstance(idist, Target)
+    assert isinstance(idist, IterablePrior)
 
 
-@pytest.mark.parametrize("dist", _builtin_distributions)
-def test_prior_construction(dist):
-    """Test that prior object can be constructed."""
-    _ = SimplePrior(dist, _batch_size, _data_shape)
-
-
-@pytest.mark.parametrize("dist", _builtin_distributions)
-def test_prior_shape(dist):
-    """Test that sample and log prob are correct shape."""
-    prior = SimplePrior(dist, _batch_size, _data_shape)
-
-    sample, log_prob = next(prior)
-
-    assert sample.shape == torch.Size(
-        [_batch_size, *_data_shape, *dist.event_shape]
+@pytest.mark.parametrize("dist", _distributions)
+@given(
+    data_shape=st.lists(st.integers(1, 10), min_size=0, max_size=2),
+    batch_shape=st.lists(st.integers(1, 10), min_size=0, max_size=2),
+)
+def test_expand_dist(dist, data_shape, batch_shape):
+    edist = expand_dist(dist, data_shape, batch_shape)
+    assert list(edist.event_shape) == (
+        data_shape + list(dist.batch_shape) + list(dist.event_shape)
     )
-    assert log_prob.shape == torch.Size([_batch_size])
+    assert list(edist.batch_shape) == batch_shape
 
 
-@pytest.mark.parametrize("dist", _builtin_distributions)
-def test_sample_values(dist):
-    """Test that sample and log prob match those of given distribution."""
-    prior = SimplePrior(dist, _batch_size, _data_shape)
+@pytest.mark.parametrize("prior", _distributions)
+def test_iterable_prior(prior):
+    iprior = IterablePrior(prior)
+    iprior_batch = IterablePrior(prior, [10])
 
-    seed = random.randint(int(1e9), int(1e10))
+    seed = torch.random.seed()
+    sample_1 = iprior.sample()
+    torch.random.manual_seed(seed)
+    sample_2 = next(iter(iprior))
+    assert torch.allclose(sample_1, sample_2)
 
-    torch.manual_seed(seed)
-    sample_from_dist = dist.sample([_batch_size, *_data_shape])
-    log_prob_from_dist = (
-        dist.log_prob(sample_from_dist).flatten(start_dim=1).sum(dim=1)
-    )
+    assert iprior.sample().shape == prior.event_shape
+    assert iprior_batch.sample().shape == torch.Size([10, *prior.event_shape])
 
-    torch.manual_seed(seed)
-    sample_from_prior, log_prob_from_prior = next(prior)
-
-    assert torch.allclose(sample_from_dist, sample_from_prior)
-    assert torch.allclose(log_prob_from_dist, log_prob_from_prior)
+    # test inherits attrs from inner dist
+    assert hasattr(iprior, "mean")

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,6 +1,5 @@
 import math
 import pytest
-import random
 from hypothesis import given, strategies as st
 
 import torch
@@ -13,6 +12,7 @@ _distributions = [
     torch.distributions.VonMises(0, 1),
     torch.distributions.MultivariateNormal(torch.zeros(2), torch.eye(2)),
 ]
+
 
 def test_types():
     dist = torch.distributions.Normal(0, 1)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 import random
 
 import pytest

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,14 +1,10 @@
 import pytest
 import torch
-import torchmetrics
 
-from torchnf.models import BoltzmannGenerator
-from torchnf.distributions import SimplePrior
 from torchnf.flow import Flow, FlowLayer
 from torchnf.transformers import AffineTransform, Translation
 from torchnf.conditioners import (
     SimpleConditioner,
-    MaskedConditioner,
     MaskedConditionerStructurePreserving,
 )
 from torchnf.recipes.networks import DenseNet, ConvNetCircular

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,15 +1,14 @@
 from hypothesis import given, strategies as st
 import pytest
-import random
 import torch
 
 from torchnf.transformers import (
     Translation,
     Rescaling,
     AffineTransform,
-    RQSplineTransform,
-    RQSplineTransformIntervalDomain,
-    RQSplineTransformCircularDomain,
+    # RQSplineTransform,
+    # RQSplineTransformIntervalDomain,
+    # RQSplineTransformCircularDomain,
 )
 from torchnf.utils import expand_elements
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import torch
 
-from torchnf.utils import sum_except_batch, expand_elements
+from torchnf.utils import expand_elements
 
 
 def test_expand_elements():


### PR DESCRIPTION
``distributions.py`` has been simplified and now contains the following:

Two abstract base classes:
1. ``Prior``, which implements ``log_prob`` and ``sample``
2. ``Target``, which implements ``log_prob`` only

A subclass of ``torch.utils.data.IterableDataset`` which simply wraps a ``torch.distributions.Distribution`` to make it possible to iterate over the sampling. Attributes of the wrapped dist are available by overriding ``__getattr__`` to point to the wrapped dist

A function ``expand_dist`` which lets you turn a simple distribution (e.g. ``torch.distributions.Normal(0, 1)``) into a multivariate distribution where components are i.i.d according to the simple dist. One can also expand the batch shape. This is useful to constructing simple prior distributions such as a multi-gaussian with diagonal covariance.